### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -16,9 +16,11 @@ from spektral import layers
 from spektral import utils
 from spektral.utils import plotting
 
-if sys.version[0] == '2':
+try:
     reload(sys)
     sys.setdefaultencoding('utf8')
+except NameError:
+    pass
 
 
 EXCLUDE = {}


### PR DESCRIPTION
Follows the Python porting best practice [___use feature detection instead of version detection___](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

__reload()__ was moved and __sys.setdefaultencoding()__ was removed in Python 3.