### PR TITLE
Updating the required keras version based on #12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='spektral',
     version='0.0.13',
     packages=find_packages(),
-    install_requires=['keras<2.3', 'networkx', 'pandas', 'joblib', 'matplotlib',
+    install_requires=['keras<2.2.5', 'networkx', 'pandas', 'joblib', 'matplotlib',
                       'tqdm', 'pygraphviz', 'numpy', 'scipy', 'requests',
                       'scikit-learn'],
     url='https://github.com/danielegrattarola/spektral',


### PR DESCRIPTION
Using keras<2.3 allows the installation of keras==2.2.5 which produces errors. Installing any previous versions work.