### PR TITLE
tweaking mnist script

### DIFF
--- a/examples/graph_signal_classification_mnist.py
+++ b/examples/graph_signal_classification_mnist.py
@@ -21,7 +21,7 @@ X_train, y_train, X_val, y_val, X_test, y_test, adj = mnist.load_data()
 X_train, X_val, X_test = X_train[..., None], X_val[..., None], X_test[..., None]
 N = X_train.shape[-2]      # Number of nodes in the graphs
 F = X_train.shape[-1]      # Node features dimensionality
-n_out = y_train.shape[-1]  # Dimension of the target
+n_out = 10  # Dimension of the target
 
 fltr = normalized_laplacian(adj)
 

--- a/examples/graph_signal_classification_mnist.py
+++ b/examples/graph_signal_classification_mnist.py
@@ -13,8 +13,8 @@ from spektral.utils import normalized_laplacian
 l2_reg = 5e-4         # Regularization rate for l2
 learning_rate = 1e-3  # Learning rate for SGD
 batch_size = 32       # Batch size
-epochs = 20           # Number of training epochs
-es_patience = 200     # Patience fot early stopping
+epochs = 1000         # Number of training epochs
+es_patience = 10     # Patience fot early stopping
 
 # Load data
 X_train, y_train, X_val, y_val, X_test, y_test, adj = mnist.load_data()

--- a/examples/graph_signal_classification_mnist.py
+++ b/examples/graph_signal_classification_mnist.py
@@ -13,7 +13,7 @@ from spektral.utils import normalized_laplacian
 l2_reg = 5e-4         # Regularization rate for l2
 learning_rate = 1e-3  # Learning rate for SGD
 batch_size = 32       # Batch size
-epochs = 20000        # Number of training epochs
+epochs = 20           # Number of training epochs
 es_patience = 200     # Patience fot early stopping
 
 # Load data


### PR DESCRIPTION
the dimension of the `y_train` array is 50000 and so this either has to be `np.max(y_train)+1` or just hard-coded 10. The model actually still works with 50000 there are just no cases where the output is higher than 9