### PR TITLE
Fixed GAT example on TF 2

### DIFF
--- a/examples/node_classification_gat.py
+++ b/examples/node_classification_gat.py
@@ -6,7 +6,7 @@ Petar Veličković, Guillem Cucurull, Arantxa Casanova, Adriana Romero, Pietro L
 """
 
 from tensorflow.keras.callbacks import EarlyStopping
-from tensorflow.keras.layers import Input, Dropout
+from tensorflow.keras.layers import Dropout, Input
 from tensorflow.keras.models import Model
 from tensorflow.keras.optimizers import Adam
 from tensorflow.keras.regularizers import l2
@@ -16,74 +16,78 @@ from spektral.layers import GraphAttention
 from spektral.utils.misc import add_eye
 
 # Load data
-dataset = 'cora'
+dataset = "cora"
 A, X, y, train_mask, val_mask, test_mask = citation.load_data(dataset)
 
+
 # Parameters
-channels = 8            # Number of channel in each head of the first GAT layer
-n_attn_heads = 8        # Number of attention heads in first GAT layer
-N = X.shape[0]          # Number of nodes in the graph
-F = X.shape[1]          # Original feature dimensionality
+channels = 8  # Number of channel in each head of the first GAT layer
+n_attn_heads = 8  # Number of attention heads in first GAT layer
+N = X.shape[0]  # Number of nodes in the graph
+F = X.shape[1]  # Original feature dimensionality
 n_classes = y.shape[1]  # Number of classes
-dropout = 0.6           # Dropout rate applied to the features and adjacency matrix
-l2_reg = 5e-4           # Regularization rate for l2
-learning_rate = 5e-3    # Learning rate for SGD
-epochs = 20000          # Number of training epochs
-es_patience = 100       # Patience for early stopping
+dropout = 0.5  # Dropout rate applied to the features and adjacency matrix
+l2_reg = 0  # Regularization rate for l2
+learning_rate = 3e-3  # Learning rate for SGD
+epochs = 1000  # Number of training epochs
+es_patience = 50  # Patience for early stopping
 
 # Preprocessing operations
 A = add_eye(A).toarray()  # Add self-loops
+X = X.todense()
+
 
 # Model definition
-X_in = Input(shape=(F, ))
-A_in = Input(shape=(N, ), sparse=False)
+X_in = Input(shape=(F,))
+A_in = Input(shape=(N,), sparse=False)
 
-dropout_1 = Dropout(dropout)(X_in)
-graph_attention_1 = GraphAttention(channels,
-                                   attn_heads=n_attn_heads,
-                                   concat_heads=True,
-                                   dropout_rate=dropout,
-                                   activation='elu',
-                                   kernel_regularizer=l2(l2_reg),
-                                   attn_kernel_regularizer=l2(l2_reg),
-                                   use_bias=False)([dropout_1, A_in])
-dropout_2 = Dropout(dropout)(graph_attention_1)
-graph_attention_2 = GraphAttention(n_classes,
-                                   attn_heads=1,
-                                   concat_heads=False,
-                                   dropout_rate=dropout,
-                                   activation='softmax',
-                                   kernel_regularizer=l2(l2_reg),
-                                   attn_kernel_regularizer=l2(l2_reg),
-                                   use_bias=False)([dropout_2, A_in])
+net = X_in
+
+net = Dropout(dropout)(net)
+net = GraphAttention(
+    channels,
+    attn_heads=n_attn_heads,
+    concat_heads=True,
+    dropout_rate=dropout,
+    activation="elu",
+    kernel_regularizer=l2(l2_reg),
+    attn_kernel_regularizer=l2(l2_reg),
+    use_bias=False,
+)([X_in, A_in])
+net = Dropout(dropout)(net)
+net = GraphAttention(
+    n_classes,
+    attn_heads=1,
+    concat_heads=False,
+    dropout_rate=dropout,
+    activation="softmax",
+    kernel_regularizer=l2(l2_reg),
+    attn_kernel_regularizer=l2(l2_reg),
+    use_bias=False,
+)([net, A_in])
 
 # Build model
-model = Model(inputs=[X_in, A_in], outputs=graph_attention_2)
+model = Model(inputs=[X_in, A_in], outputs=net)
 optimizer = Adam(lr=learning_rate)
-model.compile(optimizer=optimizer,
-              loss='categorical_crossentropy',
-              weighted_metrics=['acc'])
+model.compile(
+    optimizer=optimizer, loss="categorical_crossentropy", weighted_metrics=["acc"]
+)
 model.summary()
 
 # Train model
 validation_data = ([X, A], y, val_mask)
-model.fit([X, A],
-          y,
-          sample_weight=train_mask,
-          epochs=epochs,
-          batch_size=N,
-          validation_data=validation_data,
-          shuffle=False,  # Shuffling data means shuffling the whole graph
-          callbacks=[
-              EarlyStopping(patience=es_patience,  restore_best_weights=True)
-          ])
+model.fit(
+    [X, A],
+    y,
+    sample_weight=train_mask,
+    epochs=epochs,
+    batch_size=N,
+    validation_data=validation_data,
+    shuffle=False,  # Shuffling data means shuffling the whole graph
+    callbacks=[EarlyStopping(patience=es_patience, restore_best_weights=True)],
+)
 
 # Evaluate model
-print('Evaluating model.')
-eval_results = model.evaluate([X, A],
-                              y,
-                              sample_weight=test_mask,
-                              batch_size=N)
-print('Done.\n'
-      'Test loss: {}\n'
-      'Test accuracy: {}'.format(*eval_results))
+print("Evaluating model.")
+eval_results = model.evaluate([X, A], y, sample_weight=test_mask, batch_size=N)
+print("Done.\n" "Test loss: {}\n" "Test accuracy: {}".format(*eval_results))

--- a/examples/node_classification_gat.py
+++ b/examples/node_classification_gat.py
@@ -41,9 +41,8 @@ X = X.todense()
 X_in = Input(shape=(F,))
 A_in = Input(shape=(N,), sparse=False)
 
-net = X_in
 
-net = Dropout(dropout)(net)
+net = Dropout(dropout)(X_in)
 net = GraphAttention(
     channels,
     attn_heads=n_attn_heads,
@@ -91,3 +90,4 @@ model.fit(
 print("Evaluating model.")
 eval_results = model.evaluate([X, A], y, sample_weight=test_mask, batch_size=N)
 print("Done.\n" "Test loss: {}\n" "Test accuracy: {}".format(*eval_results))
+


### PR DESCRIPTION
Got the `node_classification_gat` example working on TF 2.1.0. A couple of changes:

* Had to convert `X` to dense.
* Changed some of the hyper-parameters, the previous configuration wasn't learning, the main culprit was the `l2_reg`.
* The script was formatted using `black` (sorry about this, my vscode formats on save).