### PR TITLE
 [ENH: issue #58] Realtime conversion from disjoint to batch.

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -72,7 +72,8 @@ PAGES = [
         'methods': [],
         'classes': [
             layers.InnerProduct,
-            layers.MinkowskiProduct
+            layers.MinkowskiProduct,
+            layers.Disjoint2Batch,
         ]
     },
     # Datasets #################################################################

--- a/spektral/layers/base.py
+++ b/spektral/layers/base.py
@@ -246,16 +246,12 @@ class Disjoint2Batch(Layer):
         # segment IDs
         X, A, I = inputs
 
-        # turn signals to batches
+        # turn signals and adjacencies to batches
         batch_X = ops.disjoint_signal_to_batch(X, I)
-
-        # turn adjacency to (dense) batch
-        if K.is_sparse(A):
-            A = tf.sparse.to_dense(A)
         batch_A = ops.disjoint_adjacency_to_batch(A, I)
 
         # ensure that the channel dim is known
         batch_X.set_shape((None, None, X.shape[-1]))
-        batch_A.set_shape((None, None, A.shape[-1]))
+        batch_A.set_shape((None, None, None))
 
         return batch_X, batch_A

--- a/spektral/layers/ops/modes.py
+++ b/spektral/layers/ops/modes.py
@@ -23,7 +23,6 @@ def disjoint_signal_to_batch(X: tf.Tensor, I: tf.Tensor) -> tf.Tensor:
     :return batch: Batched version of X now with shape (batch, max_nodes, features)
     """
 
-    # TODO: Use this op to generalise SortPool to disjoint graphs
     I = tf.cast(I, tf.int32)
     X = tf.cast(X, tf.float32)
 

--- a/spektral/layers/ops/modes.py
+++ b/spektral/layers/ops/modes.py
@@ -172,7 +172,7 @@ def disjoint_adjacency_to_batch(A: tf.Tensor, I: tf.Tensor) -> tf.Tensor:
 
     # reshape to be batched
     batch = tf.reshape(dense_adjacency, (n_graphs, max_n_nodes, max_n_nodes))
-
+    batch = tf.cast(batch, tf.float32)
     return batch
 
 def autodetect_mode(a, b):

--- a/spektral/layers/ops/modes.py
+++ b/spektral/layers/ops/modes.py
@@ -1,10 +1,57 @@
 from tensorflow.keras import backend as K
+import tensorflow as tf
 
 SINGLE  = 1   # Single         (rank(a)=2, rank(b)=2)
 MIXED   = 2   # Mixed          (rank(a)=2, rank(b)=3)
 iMIXED  = 3   # Inverted mixed (rank(a)=3, rank(b)=2)
 BATCH   = 4   # Batch          (rank(a)=3, rank(b)=3)
 UNKNOWN = -1  # Unknown
+
+
+def disjoint_to_batch(X: tf.Tensor, I: tf.Tensor) -> tf.Tensor:
+    """
+    Given an disjoint graph signal X and its segment IDs I, this op converts
+    it to a batched graph signal.
+
+    If the graphs have different orders, then we pad the node dimension with 0
+    rows until they all have the same size.
+
+    :param tf.Tensor X: Disjoint graph signal or adjacency of shape (nodes, features).
+    :param I: A rank 1 Tensor with segment IDs for X;
+    :return batch: Batched version of X now with shape (batch, max_nodes, features)
+    """
+    I = tf.cast(I, tf.int32)
+
+    # Number of nodes in each graph
+    num_nodes = tf.math.segment_sum(tf.ones_like(I), I)
+
+    # Getting starting index of each graph
+    start_index = tf.cumsum(num_nodes, exclusive=True)
+
+    # Number of graphs in batch
+    n_graphs = tf.shape(num_nodes)[0]
+
+    # Size of biggest graph in batch
+    max_n_nodes = tf.reduce_max(num_nodes)
+
+    # Number of overall nodes in batch
+    batch_n_nodes = tf.shape(I)[0]
+
+    # Get feature dim
+    feature_dim = tf.shape(X)[-1]
+
+    # index of non zero rows
+    index = tf.range(batch_n_nodes)
+    index = (index - tf.gather(start_index, I)) + (I * max_n_nodes)
+
+    # initial zero batch signal of correct shape
+    dense = tf.zeros((n_graphs * max_n_nodes, feature_dim))
+
+    # empty_var is a variable with unknown shape defined in the elsewhere
+    dense = tf.tensor_scatter_nd_update(dense, index[..., None], X)
+    batch = tf.reshape(dense, (n_graphs, max_n_nodes, feature_dim))
+    return batch
+
 
 def autodetect_mode(a, b):
     """

--- a/spektral/layers/ops/modes.py
+++ b/spektral/layers/ops/modes.py
@@ -1,5 +1,7 @@
 from tensorflow.keras import backend as K
 import tensorflow as tf
+from typing import Union
+import numpy as np
 
 SINGLE  = 1   # Single         (rank(a)=2, rank(b)=2)
 MIXED   = 2   # Mixed          (rank(a)=2, rank(b)=3)
@@ -8,7 +10,7 @@ BATCH   = 4   # Batch          (rank(a)=3, rank(b)=3)
 UNKNOWN = -1  # Unknown
 
 
-def disjoint_to_batch(X: tf.Tensor, I: tf.Tensor) -> tf.Tensor:
+def disjoint_signal_to_batch(X: tf.Tensor, I: tf.Tensor) -> tf.Tensor:
     """
     Given an disjoint graph signal X and its segment IDs I, this op converts
     it to a batched graph signal.
@@ -20,7 +22,10 @@ def disjoint_to_batch(X: tf.Tensor, I: tf.Tensor) -> tf.Tensor:
     :param I: A rank 1 Tensor with segment IDs for X;
     :return batch: Batched version of X now with shape (batch, max_nodes, features)
     """
+
+    # TODO: Use this op to generalise SortPool to disjoint graphs
     I = tf.cast(I, tf.int32)
+    X = tf.cast(X, tf.float32)
 
     # Number of nodes in each graph
     num_nodes = tf.math.segment_sum(tf.ones_like(I), I)
@@ -45,13 +50,130 @@ def disjoint_to_batch(X: tf.Tensor, I: tf.Tensor) -> tf.Tensor:
     index = (index - tf.gather(start_index, I)) + (I * max_n_nodes)
 
     # initial zero batch signal of correct shape
+
     dense = tf.zeros((n_graphs * max_n_nodes, feature_dim))
 
     # empty_var is a variable with unknown shape defined in the elsewhere
     dense = tf.tensor_scatter_nd_update(dense, index[..., None], X)
+
     batch = tf.reshape(dense, (n_graphs, max_n_nodes, feature_dim))
+
     return batch
 
+
+def get_graph_id(node: Union[tf.Tensor, np.array],
+                 graph_sizes: Union[tf.Tensor, np.array]) -> Union[tf.Tensor, np.array]:
+    """
+    Given a node (index) and the vector of graph sizes, this function returns the ID of the graph
+    containing the node.
+
+    :param node: tf.Tensor of shape (,)
+    :param graph_sizes: tf.Tensor of shape (num_graphs,) containing the sizes of the graphs ordered
+    by segment ID.
+    :return: tf.Tensor of shape (,). The segment ID containing the node.
+    """
+
+    cum_graph_sizes = tf.cumsum(graph_sizes, exclusive=True)
+
+    indicator_if_smaller = tf.cast(node - cum_graph_sizes >= 0,
+                                   tf.int32)
+
+    index_of_max_min = tf.reduce_sum(indicator_if_smaller) - 1
+
+    return index_of_max_min
+
+
+def get_cum_graph_size(node: Union[tf.Tensor, np.array],
+                       graph_sizes: Union[tf.Tensor, np.array]) -> Union[tf.Tensor, np.array]:
+    """
+    Returns the number of nodes contained inside graphs with smaller segment ID then node.
+
+    :param node: tf.Tensor of shape (,). Node ID
+    :param graph_sizes: tf.Tensor of shape (num_graphs,) containing the sizes of the graphs ordered
+    by segment ID.
+    :return: tf.Tensor of shape (,). The number of nodes contained in graphs with smaller segment ID.
+    """
+
+    graph_id = get_graph_id(node, graph_sizes)
+
+    return tf.cumsum(graph_sizes, exclusive=True)[graph_id]
+
+
+def vectorised_get_cum_graph_size(
+            nodes: Union[tf.Tensor, np.array],
+            graph_sizes: Union[tf.Tensor, np.array]) -> Union[tf.Tensor, np.array]:
+    """
+    Takes a list of node ids and graph sizes ordered by segment ID and returns the
+    number of nodes contained in graphs with smaller segment ID.
+
+    :param nodes: List of node ids of shape (nodes)
+    :param graph_sizes: List of graph sizes (i.e. tf.math.segment_sum(tf.ones_like(I), I) where I are the
+    segment IDs).
+    :return: A list of shape (nodes) where each entry corresponds to the number of nodes contained in graphs
+    with smaller segment ID for each node.
+    """
+
+    def fixed_cum_graph_size(node: Union[tf.Tensor, np.array]) -> Union[tf.Tensor, np.array]:
+        return get_cum_graph_size(node, graph_sizes)
+
+    return tf.map_fn(fixed_cum_graph_size, nodes)
+
+
+def disjoint_adjacency_to_batch(A: tf.Tensor, I: tf.Tensor) -> tf.Tensor:
+    """
+    Given an disjoint adjacency A and its segment IDs I, this op converts
+    it to a batched adjacency.
+
+    If the graphs have different orders, then we pad the node dimension with 0
+    rows until they all have the same size.
+
+    :param tf.Tensor A: Disjoint graph sparse adjacency of shape (nodes, nodes).
+    :param I: A rank 1 Tensor with segment IDs for X;
+    :return batch: Batched version of A now with shape (batch, max_nodes, max_nodes)
+    """
+    I = tf.cast(I, tf.int64)
+    A = tf.cast(A, tf.float32)
+    indices = A.indices
+    values = tf.cast(A.values, tf.int64)
+    i_nodes, j_nodes = indices[:, 0], indices[:, 1]
+
+    # Number of nodes in each graph
+    graph_sizes = tf.math.segment_sum(tf.ones_like(I), I)
+
+    # Size of biggest graph in batch
+    max_n_nodes = tf.reduce_max(graph_sizes)
+
+    # Number of graphs in batch
+    n_graphs = tf.shape(graph_sizes)[0]
+
+    # j nodes projected to be within the range of 0 to max_n_nodes relative to their
+    # connected component
+    relative_j_nodes = j_nodes - vectorised_get_cum_graph_size(j_nodes, graph_sizes)
+
+    # i nodes projected to be within the range of 0 to max_n_nodes relative to their
+    # connected component
+    relative_i_nodes = i_nodes - vectorised_get_cum_graph_size(i_nodes, graph_sizes)
+
+    # Now put the i nodes in the right place relative to previous graphs who now all
+    # have an order of max_n_nodes
+    spaced_i_nodes = I*max_n_nodes + relative_i_nodes
+
+    # Zip the nodes together
+    new_indices = tf.transpose(tf.stack([spaced_i_nodes, relative_j_nodes]))
+
+    # casting to same format
+    new_indices = tf.cast(new_indices, tf.int32)
+    n_graphs = tf.cast(n_graphs, tf.int32)
+    max_n_nodes = tf.cast(max_n_nodes, tf.int32)
+
+    # Fill in the values into a newly shaped batched adjacency
+    dense_adjacency = tf.scatter_nd(new_indices, values,
+                                    (n_graphs * max_n_nodes, max_n_nodes))
+
+    # reshape to be batched
+    batch = tf.reshape(dense_adjacency, (n_graphs, max_n_nodes, max_n_nodes))
+
+    return batch
 
 def autodetect_mode(a, b):
     """

--- a/tests/test_layers/test_global_pooling.py
+++ b/tests/test_layers/test_global_pooling.py
@@ -84,6 +84,20 @@ def _test_sortpool_batched(layer, k):
     assert output.shape == (batch_size, k, F)
     assert output.shape == layer_instance.compute_output_shape(X.shape)
 
+def _test_sortpool_disjoint(layer, k):
+    X = np.random.normal(size=(batch_size * N, F))
+    S = np.repeat(np.arange(batch_size), N).astype(np.int)
+    X_in = Input(shape=(F,))
+    S_in = Input(shape=(), dtype=S.dtype)
+    layer_instance = layer(k=k, disjoint=True)
+    output = layer_instance([X_in, S_in])
+    model = Model([X_in, S_in], output)
+    output = model([X, S])
+    assert output.shape == (batch_size, k, F)
+    # When creating actual graph, the batch dimension is None
+    assert output.shape[1:] == layer_instance.compute_output_shape([X.shape, S.shape])[
+        1:]
+
 
 def test_global_sum_pool():
     _test_single_mode(GlobalSumPool)
@@ -120,3 +134,4 @@ def test_global_attention_pool():
 def test_global_sort_pool():
     _test_sortpool_single(SortPool, k=6)
     _test_sortpool_batched(SortPool, k=6)
+    _test_sortpool_disjoint(SortPool, k=6)

--- a/tests/test_layers/test_ops.py
+++ b/tests/test_layers/test_ops.py
@@ -3,7 +3,7 @@ from scipy.sparse import coo_matrix
 import tensorflow as tf
 import tensorflow.keras as keras
 
-from spektral.layers import ops, GraphConv, SortPool
+from spektral.layers import ops
 from spektral.layers.base import Disjoint2Batch
 from spektral.utils import convolution
 
@@ -303,9 +303,7 @@ def test_Disjoint2Batch_as_layer():
     assert np.allclose(result_X, expected_X)
 
 
-def Disjoint2Batch_model():
-
-    A_dense = A_sparse.todense()
+def test_Disjoint2Batch_model():
 
     # now check if it works in models
     in_adj = keras.Input(shape=(5,), sparse=True)
@@ -316,7 +314,7 @@ def Disjoint2Batch_model():
 
     test_model = keras.Model(inputs=[in_x, in_adj, in_id], outputs=batch)
     test_model.summary()
-    test_model.compile(optimizer="Adam", loss="mse", metrics=["mae", "acc"])
+    test_model.compile(optimizer="Adam", loss="mse")
     print(test_model([X, A_sparse_tensor, I]))
 
 

--- a/tests/test_layers/test_ops.py
+++ b/tests/test_layers/test_ops.py
@@ -281,8 +281,6 @@ def test_Disjoint2Batch_as_layer():
     # initiate layer
     layer = Disjoint2Batch()
 
-    A_dense = A_sparse.todense()
-
     expected_X = np.array([[[1., 0.],
         [0., 1.],
         [1., 1.]],
@@ -295,8 +293,8 @@ def test_Disjoint2Batch_as_layer():
         [1., 0., 0.],
         [0., 1., 0.]],
 
-       [[0., 0., 1.],
-        [0., 1., 0.],
+       [[0., 1., 0.],
+        [1., 0., 0.],
         [0., 0., 0.]]])
 
     result_X, result_A = layer((X, A_sparse_tensor, I))
@@ -304,14 +302,8 @@ def test_Disjoint2Batch_as_layer():
     assert np.allclose(result_A, expected_A)
     assert np.allclose(result_X, expected_X)
 
-    # test on dense adjacencies
-    result_X, result_A = layer((X, A_dense, I))
 
-    assert np.allclose(result_A, expected_A)
-    assert np.allclose(result_X, expected_X)
-
-
-def test_Disjoint2Batch_model():
+def Disjoint2Batch_model():
 
     A_dense = A_sparse.todense()
 

--- a/tests/test_layers/test_ops.py
+++ b/tests/test_layers/test_ops.py
@@ -205,3 +205,25 @@ def test_misc_ops():
     k = 4
     expected_output = np.array([np.linalg.matrix_power(a, k) for a in A])
     _check_op(ops.matrix_power, [A], expected_output, convert_to_sparse, k=k)
+
+
+def test_disjoint_to_batch_signal():
+
+    # setting test signal and adjacency
+    X = [[1, 0], [0, 1], [1, 1], [0, 0], [1, 2]]
+    I = [0, 0, 0, 1, 1]
+
+    expected_result = np.array([
+        [[1., 0.],
+        [0., 1.],
+        [1., 1.]],
+       [[0., 0.],
+        [1., 2.],
+        [0., 0.]]])
+
+    result = ops.disjoint_to_batch(X, I)
+    result = np.array(result)
+
+    assert expected_result.shape == result.shape
+    assert np.allclose(expected_result, result) is True
+

--- a/tests/test_layers/test_ops.py
+++ b/tests/test_layers/test_ops.py
@@ -278,9 +278,6 @@ def test_disjoint_adjacency_to_batch():
 
 def test_Disjoint2Batch_as_layer():
 
-    # initiate layer
-    layer = Disjoint2Batch()
-
     expected_X = np.array([[[1., 0.],
         [0., 1.],
         [1., 1.]],
@@ -297,25 +294,18 @@ def test_Disjoint2Batch_as_layer():
         [1., 0., 0.],
         [0., 0., 0.]]])
 
-    result_X, result_A = layer((X, A_sparse_tensor, I))
+    # check mode 1
+    result_X = Disjoint2Batch()((X, I))
+    assert np.allclose(result_X, expected_X)
 
+    # check mode 2
+    result_A = Disjoint2Batch(only_adjaceny=True)((A_sparse_tensor, I))
+    assert np.allclose(result_A, expected_A)
+
+    # check mode 3
+    result_X, result_A = Disjoint2Batch()((X, A_sparse_tensor, I))
     assert np.allclose(result_A, expected_A)
     assert np.allclose(result_X, expected_X)
 
+    # TODO: Test in real models.
 
-def test_Disjoint2Batch_model():
-
-    # now check if it works in models
-    in_adj = keras.Input(shape=(5,), sparse=True)
-    in_x = keras.Input(shape=(2,))
-    in_id = keras.Input(shape=())
-
-    batch = Disjoint2Batch()([in_x, in_adj, in_id])
-
-    test_model = keras.Model(inputs=[in_x, in_adj, in_id], outputs=batch)
-    test_model.summary()
-    test_model.compile(optimizer="Adam", loss="mse")
-    print(test_model([X, A_sparse_tensor, I]))
-
-
-    # TODO finish testing Disjoint2Batch in real models


### PR DESCRIPTION
Added ops to turn disjoint signals and adjacencies into batches.

- `ops.disjoint_signal_to_batch` is a function that turns disjoint graph signals into batch mode graph signals with the usual padding
- `ops.disjoint_adjacency_to_batch` turns disjoint adjacencies into batch mode graph signals. Also with the usual padding.
- Added tests for both.
- Started work on the `Disjoint2Batch` layer