### PR TITLE
Find SyntaxWarnings on Python >= 3.8

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: System Dependencies
@@ -49,4 +49,5 @@ jobs:
           python $c_py
         done
         cd ..
-        
+        pip install flake8
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,6 +13,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
+    - name: Lint Python code
+      run: |
+        pip install flake8
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: System Dependencies
       run: |
         sudo apt-get update
@@ -49,5 +53,3 @@ jobs:
           python $c_py
         done
         cd ..
-        pip install flake8
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/spektral/datasets/delaunay.py
+++ b/spektral/datasets/delaunay.py
@@ -98,9 +98,9 @@ def generate_data(classes=0, n_samples_in_class=1000, n_nodes=7, support_low=0.,
     if one_hot_labels:
         labels = label_to_one_hot(labels, labels=classes)
 
-    if return_type is 'numpy':
+    if return_type == 'numpy':
         return adjacency, node_features, labels
-    elif return_type is 'networkx':
+    elif return_type == 'networkx':
         graphs = numpy_to_nx(adjacency, node_features=node_features, nf_name='coords')
         return graphs, labels
     else:

--- a/spektral/datasets/qm9.py
+++ b/spektral/datasets/qm9.py
@@ -70,13 +70,13 @@ def load_data(nf_keys=None, ef_keys=None, auto_pad=True, self_loops=False,
     labels = load_csv(labels_file)
     if amount is not None:
         labels = labels[:amount]
-    if return_type is 'sdf':
+    if return_type == 'sdf':
         return data, labels
     else:
         # Convert to Networkx
         data = [sdf_to_nx(_) for _ in data]
 
-    if return_type is 'numpy':
+    if return_type == 'numpy':
         if nf_keys is not None:
             if isinstance(nf_keys, str):
                 nf_keys = [nf_keys]
@@ -92,7 +92,7 @@ def load_data(nf_keys=None, ef_keys=None, auto_pad=True, self_loops=False,
                                   auto_pad=auto_pad, self_loops=self_loops,
                                   nf_keys=nf_keys, ef_keys=ef_keys)
         return adj, nf, ef, labels
-    elif return_type is 'networkx':
+    elif return_type == 'networkx':
         return data, labels
     else:
         # Should not get here

--- a/spektral/utils/misc.py
+++ b/spektral/utils/misc.py
@@ -142,7 +142,7 @@ def int_to_one_hot(x, n=None):
                                  'n ({}), therefore 1-of-n encoding is not '
                                  'possible'.format(np.max(x), n))
         x = np.array(x, dtype=np.int)
-        if x.ndim is 1:
+        if x.ndim == 1:
             x = x[:, None]
         orig_shp = x.shape
         x = np.reshape(x, (-1, orig_shp[-1]))


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> 0 is 0
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```