### PR TITLE
Made weighting consistent with original GCN implementation

### DIFF
--- a/examples/node_prediction/citation_cheby.py
+++ b/examples/node_prediction/citation_cheby.py
@@ -1,13 +1,18 @@
 """
-This example implements the experiments on citation networks using convolutional
-layers from the paper:
+This example implements the experiments on citation networks from the paper:
+
+Semi-Supervised Classification with Graph Convolutional Networks (https://arxiv.org/abs/1609.02907)
+Thomas N. Kipf, Max Welling
+
+using the convolutional layers described in:
 
 Convolutional Neural Networks on Graphs with Fast Localized Spectral Filtering (https://arxiv.org/abs/1606.09375)
 Michaël Defferrard, Xavier Bresson, Pierre Vandergheynst
 """
-
+import numpy as np
 from tensorflow.keras.callbacks import EarlyStopping
 from tensorflow.keras.layers import Input, Dropout
+from tensorflow.keras.losses import CategoricalCrossentropy
 from tensorflow.keras.models import Model
 from tensorflow.keras.optimizers import Adam
 from tensorflow.keras.regularizers import l2
@@ -20,13 +25,22 @@ from spektral.transforms import LayerPreprocess, AdjToSpTensor
 # Load data
 dataset = Citation('cora',
                    transforms=[LayerPreprocess(ChebConv), AdjToSpTensor()])
-mask_tr, mask_va, mask_te = dataset.mask_tr, dataset.mask_va, dataset.mask_te
+
+
+# We convert the binary masks to sample weights so that we can compute the
+# average loss over the nodes (following original implementation by
+# Kipf & Welling)
+def mask_to_weights(mask):
+    return mask / np.count_nonzero(mask)
+
+weights_tr, weights_va, weights_te = (mask_to_weights(mask) for mask in (
+      dataset.mask_tr, dataset.mask_va, dataset.mask_te))
 
 # Parameters
 channels = 16          # Number of channels in the first layer
 K = 2                  # Max degree of the Chebyshev polynomials
 dropout = 0.5          # Dropout rate for the features
-l2_reg = 5e-4 / 2      # L2 regularization rate
+l2_reg = 5e-4          # L2 regularization rate
 learning_rate = 1e-2   # Learning rate
 epochs = 200           # Number of training epochs
 patience = 10          # Patience for early stopping
@@ -56,13 +70,13 @@ gc_2 = ChebConv(n_out,
 model = Model(inputs=[x_in, a_in], outputs=gc_2)
 optimizer = Adam(lr=learning_rate)
 model.compile(optimizer=optimizer,
-              loss='categorical_crossentropy',
+              loss=CategoricalCrossentropy(reduction='sum'),  # To compute mean
               weighted_metrics=['acc'])
 model.summary()
 
 # Train model
-loader_tr = SingleLoader(dataset, sample_weights=mask_tr)
-loader_va = SingleLoader(dataset, sample_weights=mask_va)
+loader_tr = SingleLoader(dataset, sample_weights=weights_tr)
+loader_va = SingleLoader(dataset, sample_weights=weights_va)
 model.fit(loader_tr.load(),
           steps_per_epoch=loader_tr.steps_per_epoch,
           validation_data=loader_va.load(),
@@ -72,7 +86,7 @@ model.fit(loader_tr.load(),
 
 # Evaluate model
 print('Evaluating model.')
-loader_te = SingleLoader(dataset, sample_weights=mask_te)
+loader_te = SingleLoader(dataset, sample_weights=weights_te)
 eval_results = model.evaluate(loader_te.load(), steps=loader_te.steps_per_epoch)
 print('Done.\n'
       'Test loss: {}\n'

--- a/examples/node_prediction/citation_gcn.py
+++ b/examples/node_prediction/citation_gcn.py
@@ -4,9 +4,11 @@ This example implements the experiments on citation networks from the paper:
 Semi-Supervised Classification with Graph Convolutional Networks (https://arxiv.org/abs/1609.02907)
 Thomas N. Kipf, Max Welling
 """
+import numpy as np
 
 from tensorflow.keras.callbacks import EarlyStopping
 from tensorflow.keras.layers import Input, Dropout
+from tensorflow.keras.losses import CategoricalCrossentropy
 from tensorflow.keras.models import Model
 from tensorflow.keras.optimizers import Adam
 from tensorflow.keras.regularizers import l2
@@ -19,7 +21,12 @@ from spektral.transforms import LayerPreprocess, AdjToSpTensor
 # Load data
 dataset = Citation('cora',
                    transforms=[LayerPreprocess(GCNConv), AdjToSpTensor()])
-mask_tr, mask_va, mask_te = dataset.mask_tr, dataset.mask_va, dataset.mask_te
+
+def mask_to_weights(mask):
+      return mask / np.count_nonzero(mask)
+
+weights_tr, weights_va, weights_te = (mask_to_weights(mask) for mask in (
+      dataset.mask_tr, dataset.mask_va, dataset.mask_te))
 
 # Parameters
 channels = 16          # Number of channels in the first layer
@@ -52,13 +59,13 @@ gc_2 = GCNConv(n_out,
 model = Model(inputs=[x_in, a_in], outputs=gc_2)
 optimizer = Adam(lr=learning_rate)
 model.compile(optimizer=optimizer,
-              loss='categorical_crossentropy',
+              loss=CategoricalCrossentropy(reduction='sum'),
               weighted_metrics=['acc'])
 model.summary()
 
 # Train model
-loader_tr = SingleLoader(dataset, sample_weights=mask_tr)
-loader_va = SingleLoader(dataset, sample_weights=mask_va)
+loader_tr = SingleLoader(dataset, sample_weights=weights_tr)
+loader_va = SingleLoader(dataset, sample_weights=weights_va)
 model.fit(loader_tr.load(),
           steps_per_epoch=loader_tr.steps_per_epoch,
           validation_data=loader_va.load(),
@@ -68,7 +75,7 @@ model.fit(loader_tr.load(),
 
 # Evaluate model
 print('Evaluating model.')
-loader_te = SingleLoader(dataset, sample_weights=mask_te)
+loader_te = SingleLoader(dataset, sample_weights=weights_te)
 eval_results = model.evaluate(loader_te.load(), steps=loader_te.steps_per_epoch)
 print('Done.\n'
       'Test loss: {}\n'


### PR DESCRIPTION
This PR makes weighting of samples consistent with the [original implementation](https://github.com/tkipf/gcn/blob/master/gcn/metrics.py#L4). Note this also makes results on `pubmed` consistent with those published.

There are other gcn examples that could use the same fix that I am happy to apply this to, and potentially non-gcn examples (I haven't looked into other implementations yet). I'm happy to update this PR to include fixes to those, but I am unsure if maintainers would prefer duplicate fixes or a dataset method to load normalized weights, e.g.

```python
class Citation(Dataset):
  ...
    def load_mask(self, split='train', dtype=np.bool):
        if split == 'train':
            mask = self.mask_tr
        elif split == 'validation':
            mask = self.mask_va
        elif split == 'test':
            mask = self.mask_te
        else:
            raise ValueError(f'split must be one of "train", "validation", "test", got {split}')
        return mask.astype(dtype)
    
    def load_sample_weights(self, split='train', normalize=True, dtype=np.float32):
        weights = self.load_mask(split=split, dtype=dtype)
        if normalize:
            weights /= np.count_nonzero(weights)
        return weights
```