### PR TITLE
Removed sparse-dense-sparse topk pooling requirement

### DIFF
--- a/spektral/layers/ops/ops.py
+++ b/spektral/layers/ops/ops.py
@@ -55,56 +55,7 @@ def repeat(x, repeats):
     return result
 
 
-def segment_top_k(x, I, ratio, top_k_var):
-    """
-    Returns indices to get the top K values in x segment-wise, according to
-    the segments defined in I. K is not fixed, but it is defined as a ratio of
-    the number of elements in each segment.
-    :param x: a rank 1 Tensor;
-    :param I: a rank 1 Tensor with segment IDs for x;
-    :param ratio: float, ratio of elements to keep for each segment;
-    :param top_k_var: a tf.Variable created without shape validation (i.e.,
-    `tf.Variable(0.0, validate_shape=False)`);
-    :return: a rank 1 Tensor containing the indices to get the top K values of
-    each segment in x.
-    """
-    I = tf.cast(I, tf.int32)
-    num_nodes = tf.math.segment_sum(tf.ones_like(I), I)  # Number of nodes in each graph
-    cumsum = tf.cumsum(num_nodes)  # Cumulative number of nodes (A, A+B, A+B+C)
-    cumsum_start = cumsum - num_nodes  # Start index of each graph
-    n_graphs = tf.shape(num_nodes)[0]  # Number of graphs in batch
-    max_n_nodes = tf.reduce_max(num_nodes)  # Order of biggest graph in batch
-    batch_n_nodes = tf.shape(I)[0]  # Number of overall nodes in batch
-    to_keep = tf.math.ceil(ratio * tf.cast(num_nodes, tf.float32))
-    to_keep = tf.cast(to_keep, I.dtype)  # Nodes to keep in each graph
-
-    index = tf.range(batch_n_nodes)
-    index = (index - tf.gather(cumsum_start, I)) + (I * max_n_nodes)
-
-    y_min = tf.reduce_min(x)
-    dense_y = tf.ones((n_graphs * max_n_nodes,))
-    # subtract 1 to ensure that filler values do not get picked
-    dense_y = dense_y * tf.cast(y_min - 1, dense_y.dtype)
-    dense_y = tf.cast(dense_y, top_k_var.dtype)
-    # top_k_var is a variable with unknown shape defined in the elsewhere
-    top_k_var.assign(dense_y)
-    dense_y = tf.tensor_scatter_nd_update(top_k_var, index[..., None], tf.cast(x, top_k_var.dtype))
-    dense_y = tf.reshape(dense_y, (n_graphs, max_n_nodes))
-
-    perm = tf.argsort(dense_y, direction='DESCENDING')
-    perm = perm + cumsum_start[:, None]
-    perm = tf.reshape(perm, (-1,))
-
-    to_rep = tf.tile(tf.constant([1., 0.]), (n_graphs,))
-    rep_times = tf.reshape(tf.concat((to_keep[:, None], (max_n_nodes - to_keep)[:, None]), -1), (-1,))
-    mask = repeat(to_rep, rep_times)
-
-    perm = tf.boolean_mask(perm, mask)
-
-    return perm
-
-
-def segment_top_k_v2(x, I, ratio):
+def segment_top_k(x, I, ratio):
     """
     Returns indices to get the top K values in x segment-wise, according to
     the segments defined in I. K is not fixed, but it is defined as a ratio of

--- a/spektral/layers/pooling/topk_pool.py
+++ b/spektral/layers/pooling/topk_pool.py
@@ -33,13 +33,6 @@ class TopKPool(Pool):
     Note that the the gating operation \(\textrm{tanh}(\y)\) (Cangea et al.)
     can be replaced with a sigmoid (Gao & Ji).
 
-    This layer temporarily makes the adjacency matrix dense in order to compute
-    \(\A'\).
-    If memory is not an issue, considerable speedups can be achieved by using
-    dense graphs directly.
-    Converting a graph from sparse to dense and back to sparse is an expensive
-    operation.
-
     **Input**
 
     - Node features of shape `(n_nodes, n_node_features)`;
@@ -89,11 +82,6 @@ class TopKPool(Pool):
                                       initializer=self.kernel_initializer,
                                       regularizer=self.kernel_regularizer,
                                       constraint=self.kernel_constraint)
-        self.top_k_var = tf.Variable(0.0,
-                                     trainable=False,
-                                     validate_shape=False,
-                                     dtype=tf.keras.backend.floatx(),
-                                     shape=tf.TensorShape(None))
         super().build(input_shape)
 
     def call(self, inputs):
@@ -113,28 +101,29 @@ class TopKPool(Pool):
         # Get mask
         y = self.compute_scores(X, A, I)
         N = K.shape(X)[-2]
-        indices = ops.segment_top_k(y[:, 0], I, self.ratio, self.top_k_var)
-        mask = tf.scatter_nd(tf.expand_dims(indices, 1), tf.ones_like(indices), (N,))
+        indices = ops.segment_top_k_v2(y[:, 0], I, self.ratio)
+        indices = tf.sort(indices)  # required for ordered SparseTensors
+        mask = ops.indices_to_mask(indices, N)
 
         # Multiply X and y to make layer differentiable
         features = X * self.gating_op(y)
 
         axis = 0 if len(K.int_shape(A)) == 2 else 1  # Cannot use negative axis in tf.boolean_mask
         # Reduce X
-        X_pooled = tf.boolean_mask(features, mask, axis=axis)
+        X_pooled = tf.gather(features, indices, axis=axis)
 
         # Reduce A
-        A_dense = tf.sparse.to_dense(A) if A_is_sparse else A
-        A_pooled = tf.boolean_mask(A_dense, mask, axis=axis)
-        A_pooled = tf.boolean_mask(A_pooled, mask, axis=axis + 1)
         if A_is_sparse:
-            A_pooled = ops.dense_to_sparse(A_pooled)
+            A_pooled, _ = ops.gather_sparse_square(A, indices, mask=mask)
+        else:
+            A_pooled = tf.gather(A, indices, axis=axis)
+            A_pooled = tf.gather(A_pooled, indices, axis=axis + 1)
 
         output = [X_pooled, A_pooled]
 
         # Reduce I
         if self.data_mode == 'disjoint':
-            I_pooled = tf.boolean_mask(I[:, None], mask)[:, 0]
+            I_pooled = tf.gather(I, indices)
             output.append(I_pooled)
 
         if self.return_mask:

--- a/spektral/layers/pooling/topk_pool.py
+++ b/spektral/layers/pooling/topk_pool.py
@@ -101,7 +101,7 @@ class TopKPool(Pool):
         # Get mask
         y = self.compute_scores(X, A, I)
         N = K.shape(X)[-2]
-        indices = ops.segment_top_k_v2(y[:, 0], I, self.ratio)
+        indices = ops.segment_top_k(y[:, 0], I, self.ratio)
         indices = tf.sort(indices)  # required for ordered SparseTensors
         mask = ops.indices_to_mask(indices, N)
 

--- a/tests/test_layers/test_ops.py
+++ b/tests/test_layers/test_ops.py
@@ -296,7 +296,7 @@ def test_segment_top_k():
     x = np.array([0.2, 0.5, 0.3, -0.1, -0.2, -0.1], dtype=np.float32)
     I = np.array([0, 0, 0, 0, 1, 1], dtype=np.int64)
     ratio = 0.5
-    topk = ops.segment_top_k_v2(x, I, ratio)
+    topk = ops.segment_top_k(x, I, ratio)
     actual = topk.numpy()
     expected = [1, 2, 5]
     np.testing.assert_equal(actual, expected)

--- a/tests/test_layers/test_ops.py
+++ b/tests/test_layers/test_ops.py
@@ -290,3 +290,83 @@ def test_scatter_ops():
         out_mixed = scatter_fn(messages_random, indices, n_nodes)
         for i in range(batch_size):
             assert np.allclose(out_mixed[i], scatter_fn(messages_random[i], indices, n_nodes))
+
+
+def test_segment_top_k():
+    x = np.array([0.2, 0.5, 0.3, -0.1, -0.2, -0.1], dtype=np.float32)
+    I = np.array([0, 0, 0, 0, 1, 1], dtype=np.int64)
+    ratio = 0.5
+    topk = ops.segment_top_k_v2(x, I, ratio)
+    actual = topk.numpy()
+    expected = [1, 2, 5]
+    np.testing.assert_equal(actual, expected)
+
+
+def test_indices_to_mask_rank1():
+    indices = [1, 3, 4]
+    mask = ops.indices_to_mask(indices, 6)
+    np.testing.assert_equal(mask.numpy(), [0, 1, 0, 1, 1, 0])
+
+
+def test_indices_to_mask_rank2():
+    indices = [[0, 2], [1, 1], [2, 1]]
+    mask = ops.indices_to_mask(indices, [3, 3])
+    expected = [
+        [0, 0, 1],
+        [0, 1, 0],
+        [0, 1, 0]
+    ]
+    np.testing.assert_equal(mask.numpy(), expected)
+
+
+def random_sparse(shape, nnz, seed):
+    rng = np.random.default_rng(seed)
+    max_index = np.prod(shape)
+    indices = rng.choice(max_index, nnz, replace=False)
+    indices.sort()
+    indices = np.stack(np.unravel_index(indices, shape), axis=-1)
+    return tf.SparseTensor(indices, rng.normal(size=(nnz,)), shape)
+
+
+def test_boolean_mask_sparse():
+    st = random_sparse((5, 5), 15, seed=0)
+    dense = tf.sparse.to_dense(st)
+    mask = np.array([0, 1, 0, 1, 1], dtype=np.bool)
+    for axis in (0, 1):
+        actual, _= ops.boolean_mask_sparse(st, mask, axis=axis)
+        actual = tf.sparse.to_dense(actual).numpy()
+        expected = tf.boolean_mask(dense, mask, axis=axis).numpy()
+        np.testing.assert_equal(actual, expected)
+
+
+def test_boolean_mask_sparse_square():
+    st = random_sparse((5, 5), 15, seed=0)
+    dense = tf.sparse.to_dense(st)
+    mask = np.array([0, 1, 0, 1, 1], dtype=np.bool)
+    actual, _ = ops.boolean_mask_sparse_square(st, mask)
+    for axis in (0, 1):
+        dense = tf.boolean_mask(dense, mask, axis=axis)
+    actual = tf.sparse.to_dense(actual)
+    np.testing.assert_equal(actual.numpy(), dense.numpy())
+
+
+def test_gather_sparse():
+    st = random_sparse((5, 5), 15, seed=0)
+    dense = tf.sparse.to_dense(st)
+    indices = np.array([1, 3, 4], dtype=np.int64)
+    for axis in (0, 1):
+        actual, _= ops.gather_sparse(st, indices, axis=axis)
+        actual = tf.sparse.to_dense(actual).numpy()
+        expected = tf.gather(dense, indices, axis=axis).numpy()
+        np.testing.assert_equal(actual, expected)
+
+
+def test_gather_sparse_square():
+    st = random_sparse((5, 5), 15, seed=0)
+    dense = tf.sparse.to_dense(st)
+    indices = np.array([1, 3, 4], dtype=np.int64)
+    actual, _ = ops.gather_sparse_square(st, indices)
+    for axis in (0, 1):
+        dense = tf.gather(dense, indices, axis=axis)
+    actual = tf.sparse.to_dense(actual)
+    np.testing.assert_equal(actual.numpy(), dense.numpy())


### PR DESCRIPTION
TopK pooling currently requires a sparse-dense-sparse transformation which, as documented, is costly from a memory perspective. This PR removes that requirement.

I also snuck in a more efficient `segment_softmax`, though maybe I should have left that for another PR...

Please advise if you would prefer PRs like this discussed in issues beforehand.