### PR TITLE
Made GCN/GAT more consistent with original

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ logs/
 
 # environments
 .venv
+
+.vscode

--- a/examples/node_prediction/citation_gat.py
+++ b/examples/node_prediction/citation_gat.py
@@ -4,9 +4,11 @@ This example implements the experiments on citation networks from the paper:
 Graph Attention Networks (https://arxiv.org/abs/1710.10903)
 Petar Veličković, Guillem Cucurull, Arantxa Casanova, Adriana Romero, Pietro Liò, Yoshua Bengio
 """
-
+import numpy as np
+from tensorflow.random import set_seed
 from tensorflow.keras.callbacks import EarlyStopping
 from tensorflow.keras.layers import Input, Dropout
+from tensorflow.keras.losses import CategoricalCrossentropy
 from tensorflow.keras.models import Model
 from tensorflow.keras.optimizers import Adam
 from tensorflow.keras.regularizers import l2
@@ -16,20 +18,27 @@ from spektral.datasets.citation import Citation
 from spektral.layers import GATConv
 from spektral.transforms import LayerPreprocess, AdjToSpTensor
 
+set_seed(0)
+
 # Load data
 dataset = Citation('cora',
+                   normalize_x=True,
                    transforms=[LayerPreprocess(GATConv), AdjToSpTensor()])
-mask_tr, mask_va, mask_te = dataset.mask_tr, dataset.mask_va, dataset.mask_te
+
+def mask_to_weights(mask):
+    return mask.astype(np.float32) / np.count_nonzero(mask)
+
+weights_tr, weights_va, weights_te = (mask_to_weights(mask) for mask in (
+      dataset.mask_tr, dataset.mask_va, dataset.mask_te))
 
 # Parameters
 channels = 8           # Number of channels in each head of the first GAT layer
 n_attn_heads = 8       # Number of attention heads in first GAT layer
 dropout = 0.6          # Dropout rate for the features and adjacency matrix
-l2_reg = 5e-6          # L2 regularization rate
+l2_reg = 2.5e-4        # L2 regularization rate
 learning_rate = 5e-3   # Learning rate
 epochs = 20000         # Number of training epochs
 patience = 100         # Patience for early stopping
-a_dtype = dataset[0].a.dtype  # Only needed for TF 2.1
 
 N = dataset.n_nodes          # Number of nodes in the graph
 F = dataset.n_node_features  # Original size of node features
@@ -37,7 +46,7 @@ n_out = dataset.n_labels     # Number of classes
 
 # Model definition
 x_in = Input(shape=(F,))
-a_in = Input((N,), sparse=True, dtype=a_dtype)
+a_in = Input((N,), sparse=True)
 
 do_1 = Dropout(dropout)(x_in)
 gc_1 = GATConv(channels,
@@ -46,7 +55,8 @@ gc_1 = GATConv(channels,
                dropout_rate=dropout,
                activation='elu',
                kernel_regularizer=l2(l2_reg),
-               attn_kernel_regularizer=l2(l2_reg)
+               attn_kernel_regularizer=l2(l2_reg),
+               bias_regularizer=l2(l2_reg),
                )([do_1, a_in])
 do_2 = Dropout(dropout)(gc_1)
 gc_2 = GATConv(n_out,
@@ -55,20 +65,21 @@ gc_2 = GATConv(n_out,
                dropout_rate=dropout,
                activation='softmax',
                kernel_regularizer=l2(l2_reg),
-               attn_kernel_regularizer=l2(l2_reg)
+               attn_kernel_regularizer=l2(l2_reg),
+               bias_regularizer=l2(l2_reg),
                )([do_2, a_in])
 
 # Build model
 model = Model(inputs=[x_in, a_in], outputs=gc_2)
 optimizer = Adam(lr=learning_rate)
 model.compile(optimizer=optimizer,
-              loss='categorical_crossentropy',
+              loss=CategoricalCrossentropy(reduction='sum'),
               weighted_metrics=['acc'])
 model.summary()
 
 # Train model
-loader_tr = SingleLoader(dataset, sample_weights=mask_tr)
-loader_va = SingleLoader(dataset, sample_weights=mask_va)
+loader_tr = SingleLoader(dataset, sample_weights=weights_tr)
+loader_va = SingleLoader(dataset, sample_weights=weights_va)
 model.fit(loader_tr.load(),
           steps_per_epoch=loader_tr.steps_per_epoch,
           validation_data=loader_va.load(),
@@ -78,7 +89,7 @@ model.fit(loader_tr.load(),
 
 # Evaluate model
 print('Evaluating model.')
-loader_te = SingleLoader(dataset, sample_weights=mask_te)
+loader_te = SingleLoader(dataset, sample_weights=weights_te)
 eval_results = model.evaluate(loader_te.load(), steps=loader_te.steps_per_epoch)
 print('Done.\n'
       'Test loss: {}\n'

--- a/examples/node_prediction/citation_gat_custom.py
+++ b/examples/node_prediction/citation_gat_custom.py
@@ -17,12 +17,15 @@ from spektral.layers import GATConv
 from spektral.transforms import LayerPreprocess, AdjToSpTensor
 from spektral.utils import tic, toc
 
+tf.random.set_seed(0)
+
 # Load data
-dataset = Cora(transforms=[LayerPreprocess(GATConv), AdjToSpTensor()])
+dataset = Cora(normalize_x=True, transforms=[LayerPreprocess(GATConv), AdjToSpTensor()])
 graph = dataset[0]
 x, a, y = graph.x, graph.a, graph.y
 mask_tr, mask_va, mask_te = dataset.mask_tr, dataset.mask_va, dataset.mask_te
 
+l2_reg = 2.5e-4
 # Define model
 x_in = Input(shape=(dataset.n_node_features,))
 a_in = Input(shape=(None,), sparse=True)
@@ -32,18 +35,18 @@ x_1 = GATConv(8,
               concat_heads=True,
               dropout_rate=0.6,
               activation='elu',
-              kernel_regularizer=l2(5e-4),
-              attn_kernel_regularizer=l2(5e-4),
-              bias_regularizer=l2(5e-4))([x_1, a_in])
+              kernel_regularizer=l2(l2_reg),
+              attn_kernel_regularizer=l2(l2_reg),
+              bias_regularizer=l2(l2_reg))([x_1, a_in])
 x_2 = Dropout(0.6)(x_1)
 x_2 = GATConv(dataset.n_labels,
               attn_heads=1,
-              concat_heads=True,
+              concat_heads=False,
               dropout_rate=0.6,
               activation='softmax',
-              kernel_regularizer=l2(5e-4),
-              attn_kernel_regularizer=l2(5e-4),
-              bias_regularizer=l2(5e-4))([x_2, a_in])
+              kernel_regularizer=l2(l2_reg),
+              attn_kernel_regularizer=l2(l2_reg),
+              bias_regularizer=l2(l2_reg))([x_2, a_in])
 
 # Build model
 model = Model(inputs=[x_in, a_in], outputs=x_2)
@@ -73,6 +76,7 @@ def evaluate():
         loss = loss_fn(y[mask], predictions[mask])
         loss += sum(model.losses)
         losses.append(loss)
+        acc_fn.reset_states()
         acc = acc_fn(y[mask], predictions[mask])
         accuracies.append(acc)
     return losses, accuracies

--- a/examples/node_prediction/citation_gcn_custom.py
+++ b/examples/node_prediction/citation_gcn_custom.py
@@ -19,7 +19,7 @@ from spektral.utils import tic, toc
 tf.random.set_seed(seed=0)  # make weight initialization reproducible
 
 # Load data
-dataset = Cora(transforms=[LayerPreprocess(GCNConv), AdjToSpTensor()])
+dataset = Cora(normalize_x=True, transforms=[LayerPreprocess(GCNConv), AdjToSpTensor()])
 graph = dataset[0]
 x, a, y = graph.x, graph.a, graph.y
 mask_tr, mask_va, mask_te = dataset.mask_tr, dataset.mask_va, dataset.mask_te


### PR DESCRIPTION
This contains 3 main components:
- added `dtype` arg to `Citations` datasets with `np.float32` default, affecting all graphs. This should speed up tf training since most examples were training in `tf.float64`, and remove the `tf 2.1` requirement to specify dtypes to keras inputs (since the default data provided will be the same `dtype` as tensorflow's default)
- added `normalize_x=True` to `GAT` / `GCN` examples
- fixed minor inconsistencies in `GAT` examples, added weighting / seeds.

I could have done those all in separate PRs, but I'm trying to find a balance between single-issue PRs and avoiding merge conflicts. Let me know if I've got the balance wrong :).

Results for GCN / GAT below. Note there are some minor differences between the original GAT implementation and the one in this repository as discussed [here](https://github.com/danielegrattarola/spektral/issues/146).

| Impl. 	| Dataset  	| Reported 	| Ours 	|
|-------	|----------	|----------	|------	|
| GCN   	| Citeseer 	| 70.3     	| 71.4 	|
| GCN   	| Cora     	| 81.5     	| 82.3 	|
| GCN   	| Pubmed   	| 79.0     	| 79.3 	|
| GAT   	| Citeseer 	| 72.5     	| 70.8 	|
| GAT   	| Cora     	| 83.0     	| 82.8 	|
| GAT   	| Pubmed   	| 78.7     	| 79.0 	| 