### PR TITLE
Minor bug fix in EdgeConv, added pathsetter functionality to dataset.path

### DIFF
--- a/spektral/data/dataset.py
+++ b/spektral/data/dataset.py
@@ -210,7 +210,14 @@ class Dataset:
 
     @property
     def path(self):
-        return osp.join(DATASET_FOLDER, self.__class__.__name__)
+        try:
+            return self._path
+        except AttributeError:
+            return osp.join(DATASET_FOLDER, self.__class__.__name__)
+
+    @path.setter
+    def path(self, path):
+        self._path = path
 
     @property
     def n_graphs(self):

--- a/spektral/layers/convolutional/edge_conv.py
+++ b/spektral/layers/convolutional/edge_conv.py
@@ -99,7 +99,7 @@ class EdgeConv(MessagePassing):
         self.mlp = Sequential(
             [
                 Dense(channels, self.mlp_activation, **layer_kwargs)
-                for channels in self.mlp_hidden
+                for channels in range(self.mlp_hidden)
             ]
             + [
                 Dense(


### PR DESCRIPTION
I found that I had problems with setting a custom path, since the `@property` decorator does not allow that if one does not create a `@pathsetter` function. As is good practice, I then also made `path` a private variable: `_path`.

`EdgeConv` was missing the `range()` function in the for loop.