### PR TITLE
Fix shape of x when number of node features is 1 for a mixed mode dataset

### DIFF
--- a/spektral/data/utils.py
+++ b/spektral/data/utils.py
@@ -156,7 +156,7 @@ def to_mixed(x_list=None, a=None, e_list=None):
     # Node features
     x_out = None
     if x_list is not None:
-        x_out = np.array(x_list)
+        x_out = np.array(x_list, ndmin=2)
 
     # Edge attributes
     e_out = None


### PR DESCRIPTION
When there's only 1 node feature, x_list is a list of arrays with shape (nodes,) so np.array(x_list) returns an array of shape (batch, nodes) instead of (batch, nodes, 1). Then when running a model it was treating X as a single mode dataset with number of batches nodes and number of nodes n_feats which caused an error when trying to perform a dot product between A and X.

By forcing np.array to return a 3d array it ensures an array of the correct shape is returned but doesn't affect the output when n_feat is greater than 1. I'm not sure if something needs to be changed for the case of having 1 edge feature as well.