### PR TITLE
Sample weights for DisjointLoader

### DIFF
--- a/spektral/data/loaders.py
+++ b/spektral/data/loaders.py
@@ -350,6 +350,12 @@ class DisjointLoader(Loader):
         signature["i"]["shape"] = (None,)
         signature["i"]["dtype"] = tf.as_dtype(tf.int64)
 
+        graph = self.dataset.graphs[0]  # This is always non-empty
+        signature["w"] = dict()
+        signature["w"]["spec"] = tf.TensorSpec
+        signature["w"]["shape"] = (None,)
+        signature["w"]["dtype"] = tf.as_dtype(graph.a.dtype)  # weights type matches the adj. matrix (where they are stored)
+
         return to_tf_signature(signature)
 
 

--- a/spektral/data/utils.py
+++ b/spektral/data/utils.py
@@ -244,5 +244,10 @@ def to_tf_signature(signature):
         dtype = signature["y"]["dtype"]
         spec = signature["y"]["spec"]
         output = (output, spec(shape, dtype))
+    if "w" in signature:
+        shape = signature["w"]["shape"]
+        dtype = signature["w"]["dtype"]
+        spec = signature["w"]["spec"]
+        output = output + (spec(shape, dtype),)
 
     return output

--- a/tests/test_data/test_loaders.py
+++ b/tests/test_data/test_loaders.py
@@ -108,13 +108,14 @@ def test_disjoint():
     loader = DisjointLoader(data, batch_size=batch_size, epochs=1, shuffle=False)
     batches = list(loader)
 
-    (x, a, e, i), y = batches[-1]
+    (x, a, e, i), y, w = batches[-1]
     n = sum(ns[-graphs_in_batch:])
     assert x.shape == (n, f)
     assert a.shape == (n, n)
     assert len(e.shape) == 2 and e.shape[1] == s  # Avoid counting edges
     assert i.shape == (n,)
     assert y.shape == (graphs_in_batch, 2)
+    assert w.shape == (n,)
     assert loader.steps_per_epoch == np.ceil(len(data) / batch_size)
     signature = loader.tf_signature()
     assert len(signature[0]) == 4
@@ -127,13 +128,14 @@ def test_disjoint_node():
     )
     batches = list(loader)
 
-    (x, a, e, i), y = batches[-1]
+    (x, a, e, i), y, w = batches[-1]
     n = sum(ns[-graphs_in_batch:])
     assert x.shape == (n, f)
     assert a.shape == (n, n)
     assert len(e.shape) == 2 and e.shape[1] == s  # Avoid counting edges
     assert i.shape == (n,)
     assert y.shape == (n, 2)
+    assert w.shape == (n,)
     assert loader.steps_per_epoch == np.ceil(len(data) / batch_size)
 
     signature = loader.tf_signature()


### PR DESCRIPTION
Sample weights for training when using the `DisjointLoader` can be stored in the leading diagonal of the adjacency matrices, and then yielded from it's `collate` function. The weights are then available to feed into Keras training. This functionality is currently missing.

Proposal for solving Issue #193.