### PR TITLE
Changed dense attention mask 

### DIFF
--- a/spektral/layers/convolutional/gat_conv.py
+++ b/spektral/layers/convolutional/gat_conv.py
@@ -240,7 +240,7 @@ class GATConv(Conv):
         attn_coef = attn_for_self + attn_for_neighs
         attn_coef = tf.nn.leaky_relu(attn_coef, alpha=0.2)
 
-        mask = -10e9 * (1.0 - a)
+        mask = tf.where(a == 0., -10e9, 0.)
         attn_coef += mask[..., None, :]
         attn_coef = tf.nn.softmax(attn_coef, axis=-1)
         attn_coef_drop = self.dropout(attn_coef)

--- a/spektral/layers/convolutional/gat_conv.py
+++ b/spektral/layers/convolutional/gat_conv.py
@@ -240,7 +240,8 @@ class GATConv(Conv):
         attn_coef = attn_for_self + attn_for_neighs
         attn_coef = tf.nn.leaky_relu(attn_coef, alpha=0.2)
 
-        mask = tf.where(a == 0., -10e9, 0.)
+        mask = tf.where(a == 0.0, -10e9, 0.0)
+        mask = tf.cast(mask, dtype=attn_coef.dtype)
         attn_coef += mask[..., None, :]
         attn_coef = tf.nn.softmax(attn_coef, axis=-1)
         attn_coef_drop = self.dropout(attn_coef)


### PR DESCRIPTION
The modified dense mask supports weighted adjacency matrices since in the previous implementation 1.0-a caused the attention to be negative if a>1. 