### PR TITLE
Pass kwargs to pool() method in SRC class

### DIFF
--- a/spektral/layers/pooling/diff_pool.py
+++ b/spektral/layers/pooling/diff_pool.py
@@ -18,8 +18,8 @@ class DiffPool(SRCPool):
     This layer learns a soft clustering of the input graph as follows:
     $$
         \begin{align}
-            \S &= \textrm{GNN}_{embed}(\A, \X); \\
-            \Z &= \textrm{GNN}_{pool}(\A, \X); \\
+            \Z &= \textrm{GNN}_{embed}(\A, \X); \\
+            \S &= \textrm{GNN}_{pool}(\A, \X); \\
             \X' &= \S^\top \Z; \\
             \A' &= \S^\top \A \S; \\
         \end{align}

--- a/spektral/layers/pooling/src.py
+++ b/spektral/layers/pooling/src.py
@@ -116,7 +116,7 @@ class SRCPool(Layer):
         # Always start the call() method with get_inputs(inputs) to set self.n_nodes
         x, a, i = self.get_inputs(inputs)
 
-        return self.pool(x, a, i)
+        return self.pool(x, a, i, **kwargs)
 
     def pool(self, x, a, i, **kwargs):
         """


### PR DESCRIPTION
1. Pass the kwargs argument to pool() method in the SRC class.
2. In the diffpool paper, Z is calculated by GNN_(embed) and S is calculated by GNN_(pool). The doc mistakes these two variables.