### PR TITLE
Input independent shape to allow saving GATConv model

### DIFF
--- a/spektral/layers/convolutional/gat_conv.py
+++ b/spektral/layers/convolutional/gat_conv.py
@@ -199,7 +199,7 @@ class GATConv(Conv):
 
         # Prepare message-passing
         indices = a.indices
-        N = tf.shape(x, out_type=indices.dtype)[-2]
+        N = tf.reduce_max(indices) + 1
         if self.add_self_loops:
             indices = ops.add_self_loops_indices(indices, N)
         targets, sources = indices[:, 1], indices[:, 0]


### PR DESCRIPTION
N was None because the shape of X is [None,f], needed for 
```python
tf.math.unsorted_segment_sum(output, targets, N)
``` 
at line 225. Now N is being calculated on the fly and does not depend on the input shape, thereby avoiding None values when saving the model. 