### PR TITLE
Fix incorrectly-named bias weight.

### DIFF
--- a/spektral/layers/convolutional/censnet_conv.py
+++ b/spektral/layers/convolutional/censnet_conv.py
@@ -149,7 +149,7 @@ class CensNetConv(Conv):
             self.edge_bias = self.add_weight(
                 shape=(self.edge_channels,),
                 initializer=self.bias_initializer,
-                name="node_bias",
+                name="edge_bias",
                 regularizer=self.bias_regularizer,
                 constraint=self.bias_constraint,
             )


### PR DESCRIPTION
This isn't a huge deal, but I've seen a situation where it can break model saving in some circumstances (specifically when saving to an HDF5 file).