### PR TITLE
Stop using deprecated numpy types np.bool, np.int, and np.float

### DIFF
--- a/spektral/datasets/citation.py
+++ b/spektral/datasets/citation.py
@@ -186,7 +186,7 @@ def _read_file(path, name, suffix):
 def _idx_to_mask(idx, l):
     mask = np.zeros(l)
     mask[idx] = 1
-    return np.array(mask, dtype=np.bool)
+    return np.array(mask, dtype=bool)
 
 
 def _preprocess_features(features):

--- a/spektral/datasets/graphsage.py
+++ b/spektral/datasets/graphsage.py
@@ -203,9 +203,9 @@ def preprocess_data(path, name):
         [id_map[k] for k in id_map if k in G.nodes and G.nodes[k]["test"]],
         dtype=np.int32,
     )
-    mask_tr = np.ones(n, dtype=np.bool)
-    mask_va = np.zeros(n, dtype=np.bool)
-    mask_te = np.zeros(n, dtype=np.bool)
+    mask_tr = np.ones(n, dtype=bool)
+    mask_va = np.zeros(n, dtype=bool)
+    mask_te = np.zeros(n, dtype=bool)
     mask_tr[idx_va] = False
     mask_tr[idx_te] = False
     mask_va[idx_va] = True

--- a/spektral/datasets/mnist.py
+++ b/spektral/datasets/mnist.py
@@ -86,7 +86,7 @@ def _flip_random_edges(A, p_swap):
     if not A.shape[0] == A.shape[1]:
         raise ValueError("A must be a square matrix.")
     dtype = A.dtype
-    A = sp.lil_matrix(A).astype(np.bool)
+    A = sp.lil_matrix(A).astype(bool)
     n_elem = A.shape[0] ** 2
     n_elem_to_flip = round(p_swap * n_elem)
     unique_idx = np.random.choice(n_elem, replace=False, size=n_elem_to_flip)

--- a/spektral/utils/io.py
+++ b/spektral/utils/io.py
@@ -83,7 +83,7 @@ def load_dot(filename, force_graph=True):
                 # Probably a numpy array
                 elem[k] = np.array(
                     " ".join(v.lstrip("[").rstrip("]").split()).split(" ")
-                ).astype(np.float)
+                ).astype(float)
 
     for elem in output.edges().values():
         for k, v in elem.items():

--- a/tests/test_layers/pooling/test_global_pooling.py
+++ b/tests/test_layers/pooling/test_global_pooling.py
@@ -65,7 +65,7 @@ def _test_batch_mode(layer, **kwargs):
 
 def _test_disjoint_mode(layer, **kwargs):
     X = np.random.normal(size=(batch_size * N, F))
-    I = np.repeat(np.arange(batch_size), N).astype(np.int)
+    I = np.repeat(np.arange(batch_size), N).astype(int)
     if "target_shape" in kwargs:
         target_output_shape = kwargs.pop("target_shape")
     else:

--- a/tests/test_layers/test_ops.py
+++ b/tests/test_layers/test_ops.py
@@ -379,7 +379,7 @@ def random_sparse(shape, nnz):
 def test_boolean_mask_sparse():
     st = random_sparse((5, 5), 15)
     dense = tf.sparse.to_dense(st)
-    mask = np.array([0, 1, 0, 1, 1], dtype=np.bool)
+    mask = np.array([0, 1, 0, 1, 1], dtype=bool)
     for axis in (0, 1):
         actual, _ = ops.boolean_mask_sparse(st, mask, axis=axis)
         actual = tf.sparse.to_dense(actual).numpy()
@@ -390,7 +390,7 @@ def test_boolean_mask_sparse():
 def test_boolean_mask_sparse_square():
     st = random_sparse((5, 5), 15)
     dense = tf.sparse.to_dense(st)
-    mask = np.array([0, 1, 0, 1, 1], dtype=np.bool)
+    mask = np.array([0, 1, 0, 1, 1], dtype=bool)
     actual, _ = ops.boolean_mask_sparse_square(st, mask)
     for axis in (0, 1):
         dense = tf.boolean_mask(dense, mask, axis=axis)


### PR DESCRIPTION
Closes #414 

Change `np.bool` to `bool`, `np.int` to `int`, and `np.float` to `float`.
`np.integer` and types with the number of bytes (e.g. `np.int32` and `np.int64`) still exist, so I left them.

I could not run the tests. Maybe my installation was not fully working, or maybe it's because I don't have a GPU.